### PR TITLE
Reload page after purge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
+.idea
 /vendor/

--- a/src/spinupwp.php
+++ b/src/spinupwp.php
@@ -123,10 +123,12 @@ class SpinupWp {
 			$type  = 'page';
 		}
 
+		$redirect_url = isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : admin_url();
+
 		wp_safe_redirect( add_query_arg( array(
 			'purge_success' => (int) $purge,
 			'cache_type'    => $type,
-		), admin_url() ) );
+		), $redirect_url ) );
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/deliciousbrains/spinupwp-mu-plugin/issues/5

@gilbitron @A5hleyRich @bradt  the issue here is that we don't see the notice after the cache is cleared, as it's an admin notice:

![image](https://user-images.githubusercontent.com/1770201/53372191-1f7a9080-394a-11e9-8822-640af7c868d3.png)


